### PR TITLE
Allow dependabot-automerge to work

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: KineticCafe/actions/dependabot-automerge@v1.2
         with:
           update-type: minor
+          merge-type: rebase


### PR DESCRIPTION
This repo is restricted only to rebase merges. This fixes that issue.