### PR TITLE
result 0.6: First deprecations and renames

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# all files
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 90
+
+[*.{md,.markdown}]
+trim_trailing_whitespace = false
+max_line_length = 78
+
+[node_modules/**]
+ignore = true

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -5,16 +5,19 @@ on:
     branches:
       - main
 
-jobs:
-  deploy_pages:
-    concurrency: ci-pages-${{ github.ref }}
-    runs-on: ubuntu-latest
+  workflow_dispatch:
 
-    permissions:
-      contents: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
 
       - uses: pnpm/action-setup@v3
         with:
@@ -26,12 +29,28 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - run: pnpm install --frozen-lockfile
+      - run: |
+          pnpm install --frozen-lockfile
+          pnpm build:docs
+          touch docs/.nojekyll
 
-      - run: pnpm build:docs
-
-      - run: touch docs/.nojekyll
-
-      - uses: JamesIves/github-pages-deploy-action@v4.5.0
+      - uses: actions/upload-pages-artifact@v3
         with:
-          folder: docs
+          path: docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,43 @@
 # @kineticcafe/result
 
+## 0.6.0 / 2024-03-05
+
+- Renamed `unwrapErrors` to `unwrapErrs`, `unwrapAndThrowErrors` to `throwErrs`,
+  and `unwrapResults` to `unwrapOks`. Despite the suggestion inherent in the
+  name, an `Err` is not _necessarily_ an error, and they not related to the
+  `Error` exception class. The old names are deprecated and will be removed for
+  1.0.
+
+  The implementation for the old and new names is identical (they are documented
+  alias constants).
+
+- Improved the typings of `unwrapErrs` and `unwrapOks` so that it is clear that
+  both the input and output arrays may contain heterogeneous types. This
+  involved the use of some explicit `any` typing, but testing in the Typescript
+  playground suggests that the internal utility types `InferErr` and `InferOk`
+  cause Typescript to properly resolve disparate types.
+
+- Ensured that `new Result()` throws an exception; the only way to instantiate
+  a `Result` is through `Ok` or `Err`, which construct internal (non-exported)
+  `OkResult` and `ErrResult` classes.
+
+  - Unbound methods from `Result.prototype` throw better exceptions when
+    rebound.
+
+- Deprecated `Result#isOkAnd` and `Result#isErrAnd` in favour of `Result#isOk`
+  and `Result#isErr` with an optional predicate.
+
+- Deprecated `Result#mapOrElse` in favour of `Result#mapOr` where the provided
+  default can either be a value or a function that returns a value.
+
+- Deprecated `Result#unwrapOrElse` in favour of `Result#unwrapOr` where the
+  provided default can either be a value or a function that returns a value.
+
+- Improved documentation.
+
+- Fixed GitHub pages deploy: This has been adapted from the "Jekyll" workflow
+  that GitHub proposes.
+
 ## 0.5.0 / 2024-02-27
 
 - Initial release. The APIs are heavily based on the Rust interface, but it does

--- a/README.md
+++ b/README.md
@@ -5,8 +5,19 @@
 
 ## Description
 
-@kineticcafe/result is another Typescript implementation of the Rust `Result`
-type.
+@kineticcafe/result is another [`Result` type][wiki] implementation for
+Typescript, loosely based on Rust's [std::result][] type.
+
+`Result` types contain a value or possible error and should be used to return
+different types for success and failure without using exceptions for normal flow
+control. As the values in `Result`s are not directly accessible, there is
+explicit error handling at the point of use, through matching (`Result#match`),
+transformation (`Result#andThen`, `Result#orElse`), unwrapping (`Result#unwrap`,
+`Result#unwrapErr`), mapping (`Result#map`, `Result#mapErr`), or propagation
+(returning the result to callers).
+
+The @kineticcafe/result library additionally offers some utilities for dealing
+with arrays of `Result` types.
 
 ## Synopsis
 
@@ -14,7 +25,7 @@ type.
 import { Ok, Err } from '@kineticcafe/result'
 
 Ok(3) // A successful result
-Err('error') // An error
+Err('error') // A likely error
 ```
 
 ## Installation
@@ -23,7 +34,7 @@ Err('error') // An error
 `package.json`.
 
 ```sh
-npm add @kineticcafe/result@^0.5
+npm add @kineticcafe/result@^0.6
 ```
 
 ## Semantic Versioning
@@ -48,3 +59,5 @@ details.
 [open source projects]: https://github.com/KineticCafe
 [semantic versioning]: http://semver.org/
 [licence.md]: https://github.com/KineticCafe/result/blob/main/Licence.md
+[std::result]: https://doc.rust-lang.org/std/result/index.html
+[wiki]: https://en.wikipedia.org/wiki/Result_type

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kineticcafe/result",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A Result type loosely based on Rust Result",
   "author": "Kinetic Commerce & contributors",
   "homepage": "https://github.com/KineticCafe/result#readme",
@@ -28,7 +28,7 @@
     }
   },
   "scripts": {
-    "build": "pkgroll",
+    "build": "tsc --noEmit && pkgroll",
     "build:all": "pnpm run build && pnpm run build:docs",
     "build:docs": "typedoc",
     "build:watch": "concurrently 'pkgroll --watch' 'typedoc --watch --preserveWatchOutput'",
@@ -51,6 +51,7 @@
     "@tsconfig/recommended": "^1.0.3",
     "@types/node": "^20.11.20",
     "@vitest/coverage-v8": "^1.3.1",
+    "concurrently": "^8.2.2",
     "pkgroll": "^2.0.1",
     "publint": "^0.2.7",
     "tsx": "^4.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ devDependencies:
   '@vitest/coverage-v8':
     specifier: ^1.3.1
     version: 1.3.1(vitest@1.3.1)
+  concurrently:
+    specifier: ^8.2.2
+    version: 8.2.2
   pkgroll:
     specifier: ^2.0.1
     version: 2.0.1(typescript@5.3.3)
@@ -65,6 +68,13 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.23.9
+    dev: true
+
+  /@babel/runtime@7.24.0:
+    resolution: {integrity: sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
     dev: true
 
   /@babel/types@7.23.9:
@@ -928,8 +938,20 @@ packages:
     hasBin: true
     dev: true
 
+  /ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /ansi-sequence-parser@1.1.1:
     resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
+    dev: true
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
     dev: true
 
   /ansi-styles@5.2.0:
@@ -981,10 +1003,38 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
   /check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
     dependencies:
       get-func-name: 2.0.2
+    dev: true
+
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
   /commondir@1.0.1:
@@ -993,6 +1043,22 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
+  /concurrently@8.2.2:
+    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.1
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
     dev: true
 
   /convert-source-map@2.0.0:
@@ -1006,6 +1072,13 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
+
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.24.0
     dev: true
 
   /debug@4.3.4:
@@ -1035,6 +1108,10 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
   /esbuild@0.18.20:
@@ -1098,6 +1175,11 @@ packages:
       '@esbuild/win32-x64': 0.19.12
     dev: true
 
+  /escalade@3.1.2:
+    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
@@ -1137,6 +1219,11 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: true
+
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
   /get-func-name@2.0.2:
@@ -1228,6 +1315,11 @@ packages:
       hasown: 2.0.1
     dev: true
 
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
   /is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
     dev: true
@@ -1294,6 +1386,10 @@ packages:
     dependencies:
       mlly: 1.6.1
       pkg-types: 1.0.3
+    dev: true
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
   /loupe@2.3.7:
@@ -1543,6 +1639,15 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+    dev: true
+
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
     dev: true
@@ -1587,6 +1692,12 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.6.2
+    dev: true
+
   /sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -1612,6 +1723,10 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
+
+  /shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
   /shiki@0.14.7:
@@ -1647,12 +1762,32 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
+    dev: true
+
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
   /std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+    dev: true
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
+  /strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
     dev: true
 
   /strip-final-newline@3.0.0:
@@ -1669,6 +1804,13 @@ packages:
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
     dev: true
@@ -1704,6 +1846,15 @@ packages:
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
+    dev: true
+
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+    dev: true
+
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
   /tsx@4.7.1:
@@ -1907,12 +2058,44 @@ packages:
       stackback: 0.0.2
     dev: true
 
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
 
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.2
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: true
 
   /yocto-queue@1.0.0:

--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -3,7 +3,7 @@ module.exports = {
   entryPoints: ['src/index.ts'],
   excludeInternal: true,
   includeVersion: true,
-  intentionallyNotExported: ['Match'],
+  intentionallyNotExported: ['ErrorClass', 'InferErr', 'InferOk'],
   plugin: ['typedoc-material-theme'],
   sort: ['static-first', 'source-order'],
 }


### PR DESCRIPTION
- Renamed `unwrapErrors` to `unwrapErrs`, `unwrapAndThrowErrors` to `throwErrs`, and `unwrapResults` to `unwrapOks`. Despite the suggestion inherent in the name, an `Err` is not _necessarily_ an error, and they not related to the `Error` exception class. The old names are deprecated and will be removed for 1.0.

  The implementation for the old and new names is identical (they are documented alias constants).

- Improved the typings of `unwrapErrs` and `unwrapOks` so that it is clear that both the input and output arrays may contain heterogeneous types. This involved the use of some explicit `any` typing, but testing in the Typescript playground suggests that the internal utility types `InferErr` and `InferOk` cause Typescript to properly resolve disparate types.

- Ensured that `new Result()` throws an exception; the only way to instantiate a `Result` is through `Ok` or `Err`, which construct internal (non-exported) `OkResult` and `ErrResult` classes.

  - Unbound methods from `Result.prototype` throw better exceptions when rebound.

- Deprecated `Result#isOkAnd` and `Result#isErrAnd` in favour of `Result#isOk` and `Result#isErr` with an optional predicate.

- Deprecated `Result#mapOrElse` in favour of `Result#mapOr` where the provided default can either be a value or a function that returns a value.

- Deprecated `Result#unwrapOrElse` in favour of `Result#unwrapOr` where the provided default can either be a value or a function that returns a value.

- Improved documentation.

- Fixed GitHub pages deploy: This has been adapted from the "Jekyll" workflow that GitHub proposes.